### PR TITLE
don't let flush interval > 60 seconds prevent waiting on queue when autoflush is disabled

### DIFF
--- a/src/MessageThread.cpp
+++ b/src/MessageThread.cpp
@@ -114,7 +114,7 @@ void MessageThread::run() {
         QMutexLocker lock(&m_queue_mutex);
         for (;;) {
             if (! m_queue.isEmpty()) break;
-            if (now - last_flush > FLUSH_INTERVAL_SECONDS) break;
+            if (autoflush && now - last_flush > FLUSH_INTERVAL_SECONDS) break;
             m_wait_condition.wait(&m_queue_mutex, FLUSH_INTERVAL_SECONDS * 500);
             now = time(NULL);
         }


### PR DESCRIPTION
It appears that once 60 seconds has elapsed since the the last flush (auto or not), the worker will poll the queue constantly instead of sleeping for another 30 seconds.  This change prevents that behavior when autoflush is disabled.